### PR TITLE
Add hspec-discover to PATH

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 PATH_add bin
+PATH_add stack-bin
 
 export SESSION_ID=0000000000
 export GITHUB_USER=manuphatak

--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 PATH_add bin
-PATH_add stack-bin
+PATH_add bin/stack
 
 export SESSION_ID=0000000000
 export GITHUB_USER=manuphatak

--- a/bin/stack/hspec-discover
+++ b/bin/stack/hspec-discover
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+stack exec hspec-discover -- "$@"

--- a/test/Template/SolutionSpec.hs
+++ b/test/Template/SolutionSpec.hs
@@ -7,7 +7,7 @@ spec :: Spec
 spec = parallel $ do
   it "solves Part 1" $ do
     input <- readFile "./test/Template/input.txt"
-    part1 input `shouldBe` "hello santa"
+    part1 input `shouldBe` "hello_santa"
   it "solves Part 2" $ do
     input <- readFile "./test/Template/input.txt"
-    part2 input `shouldBe` "hello santa"
+    part2 input `shouldBe` "hello_santa"

--- a/test/Template/input.txt
+++ b/test/Template/input.txt
@@ -1,1 +1,1 @@
-hello santa
+hello_santa


### PR DESCRIPTION
> HLS is not yet able to find project preprocessors ...

\- https://github.com/haskell/haskell-language-server#preprocessor

In other words, vscode and the language server can't provide any useful features in the spec without `hspec-discover` being on the PATH.  